### PR TITLE
Version 10 centos base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,5 @@ RUN yum update -y && \
     make \
     nodejs \
     unzip \
-    zip
-
-RUN yum clean all
+    zip && \
+    yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,13 @@
-FROM node:10-alpine
+FROM centos:8
 
-RUN apk update && \
-    apk upgrade --no-cache && \
-    apk add --no-cache \
-    bash \
+RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
+
+RUN yum update -y && \
+    yum install -y  \
     git \
     make \
-    openssh-client \
-    pkgconfig \
-    python3 \
+    nodejs \
     unzip \
     zip
 
-RUN ln -sf /bin/bash /bin/sh
-RUN ln -sf /usr/bin/python3 /usr/bin/python
-RUN sed -i 's/bin\/ash/bin\/bash/g' /etc/passwd
-
-ENTRYPOINT ["/bin/bash"]
+RUN yum clean all


### PR DESCRIPTION
Originally this project used the `node-alpine` base image to create a slimmer container. Unfortunately, due to alpine using the `musl libc` family, and all node builds having a dependence of `canvas` which in turn has a reliance on `glibc`, the incompatibility couldn't be surmounted without compromising on the size of the container and complexity of the Dockerfile.

Favouring simplicity, this PR updates the Dockerfile to use the Centos 8 base image which comes with `glibc`.

Required for DVOP-1322