### PR TITLE
Update node16 build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ RUN yum update -y && \
     alsa-lib.x86_64 \
     atk.x86_64 \
     cups-libs.x86_64 \
+    gcc \
+    gcc-c++ \
     GConf2.x86_64 \
     git \
     gtk3.x86_64 \
     libdrm \
     libgbm \
+    libtiff-tools \
     libX11 \
     libXcomposite.x86_64 \
     libXcursor.x86_64 \


### PR DESCRIPTION
Updated node16 build image to include additional tooling and dependencies
- `gcc`
- `gcc-c++`
- `libtiff-tools`